### PR TITLE
Add missing #include <functional>

### DIFF
--- a/src/ExceptionHandling/BlazingThread.h
+++ b/src/ExceptionHandling/BlazingThread.h
@@ -10,6 +10,7 @@
 
 #include "BlazingException.h"
 #include "BlazingExceptionHolder.h"
+#include <functional>
 #include <thread>
 
 class BlazingThread {


### PR DESCRIPTION
This commit fixes a build failure on Ubuntu 18.04 with GCC 7.4